### PR TITLE
change name of git remote from "upstream" to "pantheon"

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -24,8 +24,8 @@ PANTHEON_GIT_URL=$(terminus site connection-info --field=git_url --site=$PANTHEO
 ###
 git clone git://develop.git.wordpress.org/ wordpress-develop
 cd wordpress-develop
-git remote add upstream $PANTHEON_GIT_URL
-git push -f upstream master:$PANTHEON_BRANCH
+git remote add pantheon $PANTHEON_GIT_URL
+git push -f pantheon master:$PANTHEON_BRANCH
 cd ../
 
 ###
@@ -45,7 +45,7 @@ git add -f test-runner.php wp-cli.local.yml wp-tests-config.php vendor
 git config --global user.email "wordpress-develop@getpantheon.com"
 git config --global user.name "Pantheon"
 git commit -m "Include requisite test runner dependencies"
-git push upstream master:$PANTHEON_BRANCH
+git push pantheon master:$PANTHEON_BRANCH
 cd ../
 
 ###


### PR DESCRIPTION
I was confused for a half-second when I saw `git push upstream` simply because Pantheon uses "upstream" in the context of repos external to Pantheon like https://github.com/pantheon-systems/WordPress

Also, I just want to see CircleCI run on Pull Request. Though I don't know if that run will happen across forks.
